### PR TITLE
Skip git working tree check

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ First, commit any changes, as we don't want to mess anything up. The script won'
 
 Then run `npm run install-colo-loco` or `yarn install-colo-loco`. This will attempt to automatically patch the necessary files.
 
+_NOTE: It's recommended to run this script with a clean git working tree, if you want to continue without a dirty working tree pass it the `--no-git-check` flag_
+
 Lastly, run `npx pod-install` and then `npm run ios`/`yarn ios` and `npm run android`/`yarn android` to finish installation and compile.
 
 _NOTE: If this doesn't work or you have a non-standard project structure, try the manual instructions below._

--- a/scripts/install-colo-loco
+++ b/scripts/install-colo-loco
@@ -2,8 +2,10 @@
 
 const fs = require("fs")
 
+const noGitCheck = process.argv.includes("--no-git-check")
+
 // check if their git working tree is dirty
-if (isGitDirty()) {
+if (!noGitCheck && isGitDirty()) {
   console.error("Your git working tree is dirty. Please commit or stash your changes before running this script.")
   process.exit(1)
 }

--- a/scripts/install-colo-loco
+++ b/scripts/install-colo-loco
@@ -1,60 +1,75 @@
 #!/usr/bin/env node
 
 const fs = require("fs")
-
-const noGitCheck = process.argv.includes("--no-git-check")
-
-// check if their git working tree is dirty
-if (!noGitCheck && isGitDirty()) {
-  console.error("Your git working tree is dirty. Please commit or stash your changes before running this script.")
-  process.exit(1)
-}
-
-// get the app name, source folder, and package name from command-line arguments
-const defaults = process.argv.includes("--defaults")
-
 const readline = require("readline")
+
 const rl = readline.createInterface({
   input: process.stdin,
   output: process.stdout,
 })
 
-const packageFile = fs.existsSync(process.cwd() + "/app.json") ? "app.json" : "package.json"
-const contents = fs.readFileSync(process.cwd() + "/" + packageFile)
-const package = JSON.parse(contents)
+const noGitCheck = process.argv.includes("--no-git-check")
 
-const defaultAppName = pascalCase(package.name)
+let appName, sourceFolder, packageName
 
-// look for existing folders, or default to 'app'
-let defaultSourceFolder = firstExistingFolder(["app", "src", "App", "source", "Source"]) || "app"
+// check if their git working tree is dirty
+if (!noGitCheck && isGitDirty()) {
+  console.error("Your git working tree is dirty.")
 
-const defaultPackageName = `com.${defaultAppName.toLowerCase()}`
+  rl.question("Are you sure you want to continue? [y/N] ", function (answer) {
+    // start setup if user wants to continue and exit if not
+    if (answer.toLowerCase() === "y" || answer.toLowerCase() === "yes") {
+      startSetup()
+    } else {
+      console.error("Please commit or stash your changes and re-run the script.")
+      process.exit(1)
+    }
+  })
+} else {
+  // start if git working working tree is clean or user passed the --no-git-check flag
+  startSetup()
+}
 
-let appName = defaultAppName
-let sourceFolder = defaultSourceFolder
-let packageName = defaultPackageName
+function startSetup() {
+  // get the app name, source folder, and package name from command-line arguments
+  const defaults = process.argv.includes("--defaults")
+  const packageFile = fs.existsSync(process.cwd() + "/app.json") ? "app.json" : "package.json"
+  const contents = fs.readFileSync(process.cwd() + "/" + packageFile)
+  const package = JSON.parse(contents)
 
-console.log("Setting up React Native Colo Loco!")
+  const defaultAppName = pascalCase(package.name)
 
-// if we're not using the `--defaults` flag, ask the user for the app name, source folder, and package name
-if (!defaults) {
-  // ask the user for the app name
-  rl.question(`App name? [${defaultAppName}] `, function (userAppName) {
-    // ask the user for the source folder
-    rl.question(`Source folder? [${defaultSourceFolder}] `, function (userSourceFolder) {
-      // ask the user for the app package name
-      rl.question(`App package name? [${defaultPackageName}] `, function (userPackageName) {
-        appName = userAppName || defaultAppName
-        sourceFolder = userSourceFolder || defaultSourceFolder
-        packageName = userPackageName || defaultPackageName
+  // look for existing folders, or default to 'app'
+  let defaultSourceFolder = firstExistingFolder(["app", "src", "App", "source", "Source"]) || "app"
 
-        rl.close()
+  const defaultPackageName = `com.${defaultAppName.toLowerCase()}`
+
+  appName = defaultAppName
+  sourceFolder = defaultSourceFolder
+  packageName = defaultPackageName
+
+  console.log("Setting up React Native Colo Loco!")
+
+  // if we're not using the `--defaults` flag, ask the user for the app name, source folder, and package name
+  if (!defaults) {
+    // ask the user for the app name
+    rl.question(`App name? [${defaultAppName}] `, function (userAppName) {
+      // ask the user for the source folder
+      rl.question(`Source folder? [${defaultSourceFolder}] `, function (userSourceFolder) {
+        // ask the user for the app package name
+        rl.question(`App package name? [${defaultPackageName}] `, function (userPackageName) {
+          appName = userAppName || defaultAppName
+          sourceFolder = userSourceFolder || defaultSourceFolder
+          packageName = userPackageName || defaultPackageName
+
+          rl.close()
+        })
       })
     })
-  })
-  rl.on("close", setupColoLoco)
-} else {
-  setupColoLoco()
+    rl.on("close", setupColoLoco)
+  } else {
+    setupColoLoco()
+  }
 }
 
 function setupColoLoco() {


### PR DESCRIPTION
# New Features

## --no-git-check flag

I added a `--no-git-check` flag that allows the user to skip the git working tree check.

## Ask user if they want to continue with a dirty working tree

Also, if the user doesn't pass that flag and they have a dirty working tree it will ask them if they want to continue or not (the default is to not).