### PR TITLE
Add --help argument and fix `npm run` in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Once you have installed `react-native-colo-loco`, you can try running our setup 
 
 First, commit any changes, as we don't want to mess anything up. The script won't continue if your git working tree is dirty.
 
-Then run `npm run install-colo-loco` or `yarn install-colo-loco`. This will attempt to automatically patch the necessary files.
+Then run `npx install-colo-loco` or `yarn install-colo-loco`. This will attempt to automatically patch the necessary files.
 
 Lastly, run `npx pod-install` and then `npm run ios`/`yarn ios` and `npm run android`/`yarn android` to finish installation and compile.
 

--- a/scripts/install-colo-loco
+++ b/scripts/install-colo-loco
@@ -2,6 +2,20 @@
 
 const fs = require("fs")
 
+const help = process.argv.includes("-h") || process.argv.includes("--help")
+
+if (help) {
+  console.log(" React Native Colo Loco 🤪\n")
+  console.log("    This script automates the installation of React Native Colo Loco")
+  console.log("    which allows you to colocate your native files with your JavaScript files.\n")
+  console.log(" Usage: npx install-colo-loco or yarn install-colo-loco\n")
+  console.log(" Command options:")
+  console.log("    --defaults         Use the defaults (App name, Source folder and Package name.")
+  console.log("    -h, --help         Print usage info.")
+  console.log("    --skip-git-check   Skip git working tree (install with dirty git working tree).")
+  process.exit(0)
+}
+
 // check if their git working tree is dirty
 if (isGitDirty()) {
   console.error("Your git working tree is dirty. Please commit or stash your changes before running this script.")


### PR DESCRIPTION
# New Features

## `--help` Argument

Add a `--help` (or `-h`) argument that prints a usage guide with all the command and options of the script
_NOTE: I pre-added the `--no-git-check` command in this PR #4, If you don't want it, kindly leave a comment._

## Change `npm run install-colo-loco` in README to `npx install-colo-loco`

If you're using npm you can't actually use `npm run some-package-bin` unless it's added as a script in the app's package.json, instead you can use `npx install-colo-loco`.