### PR TITLE
Fix merge conflict for --no-git-check flag

### DIFF
--- a/scripts/install-colo-loco
+++ b/scripts/install-colo-loco
@@ -16,15 +16,7 @@ if (help) {
   process.exit(0)
 }
 
-// check if their git working tree is dirty
-if (isGitDirty()) {
-  console.error("Your git working tree is dirty. Please commit or stash your changes before running this script.")
-  process.exit(1)
-}
-
 // get the app name, source folder, and package name from command-line arguments
-const defaults = process.argv.includes("--defaults")
-
 const readline = require("readline")
 
 const rl = readline.createInterface({


### PR DESCRIPTION
Due to a merge conflict, the check for `isGitDirty()` was still present in the code, which just exits from the script even if the user passed the `--no-git-check` flag.