### PR TITLE
feat(Xcode): add support for monorepo directory structure and exclude specific targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,18 @@ link_colocated_native_files(app_name: 'MyApp', app_path: "../app")
 
 </details>
 
+#### Exclude specific Xcode targets
+
+In some cases you may want to exclude certain targets from being linked. For example, if you have a `MyAppTests` target, you may not want to link your native files into that target. To do this, the `exclude_targets` option flag specifies an array of target names to exclude. Just add the following to your Podfile:
+
+```ruby
+link_colocated_native_files(
+  app_name: 'MyApp',
+  app_path: "../app",
+  exclude_targets: ['MyAppTests']
+)
+```
+
 ### Android Manual Installation
 
 <details>
@@ -627,6 +639,6 @@ However, these are edge-cases, and likely best if you create your own package / 
 2. If you're getting obscure native errors, try opening the project in Android Studio or Xcode and building from there to get more targeted errors
 3. If you think the issue is with React Native Colo Loco, try creating a brand-new app using the instructions earlier in the README and replicate the problem there. Then file an issue with a link to the replication repo. Issues without replication steps or repos will most likely be closed without resolution because who's got time for that?
 
-If you continue having problems, join the Infinite Red Slack community at https://community.infinite.red and ask in the #react-native channel. Make sure to mention you are using React Native Colo Loco.
+If you continue having problems, join the Infinite Red Slack community at <https://community.infinite.red> and ask in the #react-native channel. Make sure to mention you are using React Native Colo Loco.
 
 If you need help from pros, consider hiring [Infinite Red](https://infinite.red/reactnative), my React Native consulting company.

--- a/scripts/ios.rb
+++ b/scripts/ios.rb
@@ -11,6 +11,7 @@ def link_colocated_native_files(options = {})
 
   app_name = options[:app_name]
   app_path = options[:app_path]
+  excluded_targets = options[:exclude_targets] || []
   project_path = "#{app_name}.xcodeproj"
 
   # if app_path/ios/Podfile exists, stop and warn the user
@@ -59,6 +60,10 @@ def link_colocated_native_files(options = {})
 
         # add the new file to all targets
         project.targets.each do |target|
+          if excluded_targets.include?(target.name)
+            # Skipping #{target.name} because it is in the excluded_targets list
+            next
+          end
           target.add_file_references([new_file])
         end
       # end

--- a/scripts/ios.rb
+++ b/scripts/ios.rb
@@ -50,11 +50,12 @@ def link_colocated_native_files(options = {})
 
     puts "Adding co-located native files from #{app_path} to Xcode project"
     colocated_files.each do |file|
+      relative_file_path = Pathname.new(file).realpath
       puts "Adding #{file}"
       # if colocated_group.files.map(&:path).include?(file)
       #   puts "File already exists in Xcode project"
       # else
-        new_file = colocated_group.new_file(file)
+        new_file = colocated_group.new_file(relative_file_path)
 
         # add the new file to all targets
         project.targets.each do |target|


### PR DESCRIPTION
This PR adds the support for the explicit exclusion of targets within the Xcode project, to allow only those targets importing the React bridging header to compile the native modules helper files.

It also adds the support for monorepo structures by adding files to the Colocated group using their absolute path, in order to avoid a broken reference to the colocated files.